### PR TITLE
Update wiring_analog.c, add wait for ongoing in analogRead

### DIFF
--- a/pic32/cores/pic32/wiring_analog.c
+++ b/pic32/cores/pic32/wiring_analog.c
@@ -545,6 +545,9 @@ uint32_t analogReadConversion(){
 
 int analogRead(uint8_t pin)
 {
+  // In case a non-blocking read is in progress, wait for it to complete.
+  while( ! analogReadConversionComplete() );
+
   if (!analogReadConversionStart(pin)) return 0;
   while( ! analogReadConversionComplete() );
   return analogReadConversion();


### PR DESCRIPTION
What do you think of this code change?  It adds a line in the blocking analogRead so it can wait for an ongoing read to complete.  Was curious if you already considered this, as you mention hanging there as one of the few issues with the API.